### PR TITLE
feat: Add 'Extract Key Information' feature to PDF Q&A app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # BookAIReader
+
+BookAIReader is a Streamlit application that allows you to interact with PDF documents using AI. You can ask questions about the content of a PDF or extract key information to quickly understand its main points.
+
+## Features
+
+-   **Interactive Q&A:** Upload a PDF and ask questions about its content. The application uses Large Language Models (LLMs) to provide answers based on the document's text.
+-   **Extract Key Information:** Get a comprehensive overview of your PDF. This feature, powered by LLMs, analyzes the text to extract:
+    -   **Main Ideas:** Identifies the core concepts and central arguments presented in the document.
+    -   **Useful Information:** Extracts key facts, data points, or valuable insights.
+    -   **Quotable Passages:** Pinpoints impactful sentences or phrases that are representative of the text's message.
+    -   **Concise Summary:** Provides a brief yet comprehensive overview of the entire text, focusing on the most critical information.
+    This functionality allows users to achieve a faster and simpler understanding of the PDF content.
+
+## How to Use
+
+1.  **Upload a PDF:** Use the file uploader to select the PDF document you want to analyze.
+2.  **Select a Model:** Choose one of the available LLMs from the dropdown menu. Different models may provide different nuances in their responses.
+3.  **Ask a Question (Optional):** If you have a specific question about the PDF, type it into the text input field and click "Submit Q&A". The answer will be displayed.
+4.  **Extract Key Information (Optional):** To get the structured summary of the PDF, simply click the "Extract Key Information" button after uploading the PDF and selecting a model. The extracted details will appear in an expandable section.
+
+## Setup and Installation
+
+(To be added: Detailed instructions on how to set up the local environment, install dependencies, and run the application.)

--- a/app.py
+++ b/app.py
@@ -6,6 +6,31 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def extract_key_info(pdf_text, model_name):
+    """
+    Extracts key information from PDF text using an LLM.
+    """
+    prompt = f"""Analyze the following text and provide a comprehensive summary that includes:
+
+1.  **Main Ideas:** Identify the core concepts and arguments presented.
+2.  **Useful Information:** Extract key facts, data, or insights that are particularly valuable.
+3.  **Quotable Passages:** Pinpoint specific sentences or phrases that are impactful, insightful, or representative of the text's message.
+4.  **Concise Summary:** Provide a brief overview of the entire text, removing any redundancies and focusing on the most critical information.
+
+Here is the text:
+
+{pdf_text}
+
+Please structure your response clearly, using headings for each section (Main Ideas, Useful Information, Quotable Passages, Concise Summary).
+"""
+    messages = [{"role": "user", "content": prompt}]
+    response = completion(
+        model=model_name,
+        messages=messages,
+    )
+    return response.choices[0].message.content
+
+
 def main():
     st.title("PDF Q&A App")
     uploaded_file = st.file_uploader("Upload a PDF", type=["pdf"])
@@ -21,8 +46,14 @@ def main():
                 "gemini/gemini-2.0-flash-thinking-exp-01-21",
             ]
             selected_model = st.selectbox("Select model:", models)
-            submitted = st.form_submit_button("Submit")
-            if submitted and query:
+            
+            col1, col2 = st.columns(2)
+            with col1:
+                qa_submitted = st.form_submit_button("Submit Q&A")
+            with col2:
+                extract_submitted = st.form_submit_button("Extract Key Information")
+
+            if qa_submitted and query:
                 messages = [
                     {
                         "role": "user",
@@ -34,6 +65,11 @@ def main():
                     messages=messages,
                 )
                 st.write("Answer:", response.choices[0].message.content)
+            
+            if extract_submitted:
+                key_info = extract_key_info(pdf_text, selected_model)
+                with st.expander("Key Information Extracted", expanded=True):
+                    st.markdown(key_info)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit introduces a new feature that allows you to extract key information from uploaded PDF documents.

New Functionality:
- You can click an "Extract Key Information" button after uploading a PDF.
- The application then uses the selected LLM to:
    - Identify main ideas.
    - Extract useful information.
    - Pinpoint quotable passages.
    - Provide a summary of the content, removing redundancies.
- The extracted information is displayed in an expander section below the button.

This feature aims to help you read and understand books and documents more quickly and simply by leveraging the power of LLMs to distill essential content.

Changes Made:
- Added an `extract_key_info` function to `app.py` to handle the LLM interaction for this feature.
- Updated the Streamlit interface in `app.py` to include the new button and display area for the extracted information.
- Updated `README.md` to describe the new feature and its usage.